### PR TITLE
build: add primevue resolver to avoid always importing primevue components

### DIFF
--- a/data/db.json
+++ b/data/db.json
@@ -2,8 +2,8 @@
   "sales": [
     {
       "id": 1,
-      "name": "Karen",
-      "purchaseDate": "2025-03-18",
+      "name": "Jack Johnson",
+      "purchaseDate": "2025-03-24",
       "numberOfCards": 2,
       "totalAmount": 1000,
       "numberOfInstallments": 4,
@@ -11,21 +11,264 @@
     },
     {
       "id": 2,
-      "name": "Jane",
-      "purchaseDate": "2025-04-07",
+      "name": "Scarlett Lee",
+      "purchaseDate": "2025-06-26",
       "numberOfCards": 3,
       "totalAmount": 1500,
       "numberOfInstallments": 4,
-      "firstDueDate": "2025-04-15"
+      "firstDueDate": "2025-06-30"
     },
     {
       "id": 3,
-      "name": "Alex",
-      "purchaseDate": "2025-06-30",
+      "name": "Emma Robinson",
+      "purchaseDate": "2025-03-04",
+      "numberOfCards": 2,
+      "totalAmount": 1000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-03-15"
+    },
+    {
+      "id": 4,
+      "name": "Scarlett Lewis",
+      "purchaseDate": "2025-07-27",
+      "numberOfCards": 2,
+      "totalAmount": 1000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-07-31"
+    },
+    {
+      "id": 5,
+      "name": "Amelia Thomas",
+      "purchaseDate": "2025-06-04",
+      "numberOfCards": 4,
+      "totalAmount": 2000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-06-15"
+    },
+    {
+      "id": 6,
+      "name": "James Davis",
+      "purchaseDate": "2025-07-04",
+      "numberOfCards": 4,
+      "totalAmount": 2000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-07-15"
+    },
+    {
+      "id": 7,
+      "name": "Sophia Taylor",
+      "purchaseDate": "2025-05-01",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-05-15"
+    },
+    {
+      "id": 8,
+      "name": "Emma Harris",
+      "purchaseDate": "2025-01-15",
+      "numberOfCards": 4,
+      "totalAmount": 2000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-01-31"
+    },
+    {
+      "id": 9,
+      "name": "Victoria Moore",
+      "purchaseDate": "2025-06-13",
+      "numberOfCards": 2,
+      "totalAmount": 1000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-06-15"
+    },
+    {
+      "id": 10,
+      "name": "Logan Walker",
+      "purchaseDate": "2025-07-10",
       "numberOfCards": 1,
       "totalAmount": 500,
       "numberOfInstallments": 4,
       "firstDueDate": "2025-07-15"
+    },
+    {
+      "id": 11,
+      "name": "Sebastian Gonzalez",
+      "purchaseDate": "2025-04-04",
+      "numberOfCards": 4,
+      "totalAmount": 2000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-04-15"
+    },
+    {
+      "id": 12,
+      "name": "Victoria Johnson",
+      "purchaseDate": "2025-04-26",
+      "numberOfCards": 1,
+      "totalAmount": 500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-04-30"
+    },
+    {
+      "id": 13,
+      "name": "Emma Sanchez",
+      "purchaseDate": "2025-04-28",
+      "numberOfCards": 2,
+      "totalAmount": 1000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-04-30"
+    },
+    {
+      "id": 14,
+      "name": "Mason Jackson",
+      "purchaseDate": "2025-03-13",
+      "numberOfCards": 1,
+      "totalAmount": 500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-03-15"
+    },
+    {
+      "id": 15,
+      "name": "Liam White",
+      "purchaseDate": "2025-02-10",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-02-15"
+    },
+    {
+      "id": 16,
+      "name": "Wyatt Wilson",
+      "purchaseDate": "2025-07-24",
+      "numberOfCards": 4,
+      "totalAmount": 2000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-07-31"
+    },
+    {
+      "id": 17,
+      "name": "Amelia Lewis",
+      "purchaseDate": "2025-05-06",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-05-15"
+    },
+    {
+      "id": 18,
+      "name": "Wyatt Smith",
+      "purchaseDate": "2025-01-24",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-01-31"
+    },
+    {
+      "id": 19,
+      "name": "Scarlett Hernandez",
+      "purchaseDate": "2025-04-08",
+      "numberOfCards": 2,
+      "totalAmount": 1000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-04-15"
+    },
+    {
+      "id": 20,
+      "name": "Amelia Johnson",
+      "purchaseDate": "2025-01-14",
+      "numberOfCards": 4,
+      "totalAmount": 2000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-01-15"
+    },
+    {
+      "id": 21,
+      "name": "Liam Taylor",
+      "purchaseDate": "2025-05-02",
+      "numberOfCards": 2,
+      "totalAmount": 1000,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-05-15"
+    },
+    {
+      "id": 22,
+      "name": "David White",
+      "purchaseDate": "2025-02-09",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-02-15"
+    },
+    {
+      "id": 23,
+      "name": "Wyatt Harris",
+      "purchaseDate": "2025-03-04",
+      "numberOfCards": 1,
+      "totalAmount": 500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-03-15"
+    },
+    {
+      "id": 24,
+      "name": "Liam Johnson",
+      "purchaseDate": "2025-01-23",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-01-31"
+    },
+    {
+      "id": 25,
+      "name": "Ava Martin",
+      "purchaseDate": "2025-01-08",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-01-15"
+    },
+    {
+      "id": 26,
+      "name": "Daniel Gonzalez",
+      "purchaseDate": "2025-06-01",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-06-15"
+    },
+    {
+      "id": 27,
+      "name": "Ethan Brown",
+      "purchaseDate": "2025-01-01",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-01-15"
+    },
+    {
+      "id": 28,
+      "name": "Victoria Davis",
+      "purchaseDate": "2025-04-29",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-04-30"
+    },
+    {
+      "id": 29,
+      "name": "Victoria Gonzalez",
+      "purchaseDate": "2025-04-24",
+      "numberOfCards": 3,
+      "totalAmount": 1500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-04-30"
+    },
+    {
+      "id": 30,
+      "name": "Matthew Lopez",
+      "purchaseDate": "2025-06-04",
+      "numberOfCards": 1,
+      "totalAmount": 500,
+      "numberOfInstallments": 4,
+      "firstDueDate": "2025-06-15"
     }
   ],
   "installments": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
+        "@primevue/auto-import-resolver": "^4.3.6",
         "@vitejs/plugin-vue": "^6.0.0",
         "sass": "^1.89.2",
         "sass-loader": "^16.0.5",
+        "unplugin-vue-components": "^28.8.0",
         "vite": "^7.0.0",
         "vite-plugin-vue-devtools": "^7.7.7"
       }
@@ -1339,6 +1341,19 @@
         "node": ">=12.11.0"
       }
     },
+    "node_modules/@primevue/auto-import-resolver": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@primevue/auto-import-resolver/-/auto-import-resolver-4.3.6.tgz",
+      "integrity": "sha512-xrncC+mnqpdyv8oePpFGGPYyhOZHV3rRlVMAzif0l9rlyJ4r/gzRI7PRLxIPmC83UqGz+PG50LvNK/5L3VEagQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@primevue/metadata": "4.3.6"
+      },
+      "engines": {
+        "node": ">=12.11.0"
+      }
+    },
     "node_modules/@primevue/core": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.3.6.tgz",
@@ -1364,6 +1379,16 @@
         "@primeuix/utils": "^0.6.0",
         "@primevue/core": "4.3.6"
       },
+      "engines": {
+        "node": ">=12.11.0"
+      }
+    },
+    "node_modules/@primevue/metadata": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@primevue/metadata/-/metadata-4.3.6.tgz",
+      "integrity": "sha512-dncVsMYxFvrx7FYDH8MQMtd6xkNQMVuCwpnTMLIOf9BRC7zVhRQug/IWZzsbS3jgVrPsTI3KmOn4LMDhH+fapg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.11.0"
       }
@@ -2183,6 +2208,46 @@
       "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
       "license": "MIT"
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2200,6 +2265,19 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/birpc": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.4.0.tgz",
@@ -2215,7 +2293,6 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -2350,6 +2427,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2693,6 +2777,13 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -2730,7 +2821,6 @@
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2877,6 +2967,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2991,6 +3094,19 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -3013,7 +3129,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3024,7 +3139,6 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3057,7 +3171,6 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3504,6 +3617,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
+      "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.0.1",
+        "quansync": "^0.2.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/lowdb": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
@@ -3627,6 +3758,38 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -3691,6 +3854,16 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -3817,6 +3990,18 @@
         }
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
+      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -3887,6 +4072,23 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/quansync": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
+      "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/readdirp": {
@@ -4186,7 +4388,6 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4215,6 +4416,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -4236,6 +4444,125 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.5.tgz",
+      "integrity": "sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.1",
+        "picomatch": "^4.0.2",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.4.tgz",
+      "integrity": "sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/unplugin-vue-components": {
+      "version": "28.8.0",
+      "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-28.8.0.tgz",
+      "integrity": "sha512-2Q6ZongpoQzuXDK0ZsVzMoshH0MWZQ1pzVL538G7oIDKRTVzHjppBDS8aB99SADGHN3lpGU7frraCG6yWNoL5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.6.0",
+        "debug": "^4.4.1",
+        "local-pkg": "^1.1.1",
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "tinyglobby": "^0.2.14",
+        "unplugin": "^2.3.5",
+        "unplugin-utils": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@babel/parser": "^7.15.8",
+        "@nuxt/kit": "^3.2.2 || ^4.0.0",
+        "vue": "2 || 3"
+      },
+      "peerDependenciesMeta": {
+        "@babel/parser": {
+          "optional": true
+        },
+        "@nuxt/kit": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unplugin-vue-components/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/unplugin-vue-components/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/unplugin-vue-components/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4472,6 +4799,13 @@
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "@primevue/auto-import-resolver": "^4.3.6",
     "@vitejs/plugin-vue": "^6.0.0",
     "sass": "^1.89.2",
     "sass-loader": "^16.0.5",
+    "unplugin-vue-components": "^28.8.0",
     "vite": "^7.0.0",
     "vite-plugin-vue-devtools": "^7.7.7"
   }

--- a/src/assets/layout/_table.scss
+++ b/src/assets/layout/_table.scss
@@ -1,0 +1,19 @@
+.custom-table-header {
+  display: flex;
+  justify-content: space-between;
+
+  .global-filter-container {
+    display: flex;
+    gap: 0.5rem;
+  }
+}
+
+.custom-date-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.empty-data, .loading-data {
+  text-align: center;
+}

--- a/src/assets/layout/_utils.scss
+++ b/src/assets/layout/_utils.scss
@@ -21,4 +21,10 @@
     font-weight: 700;
     margin-bottom: 1rem;
   }
+
+  .card-content {
+    .p-datatable {
+      margin-top: 1.5rem;
+    }
+  }
 }

--- a/src/assets/layout/layout.scss
+++ b/src/assets/layout/layout.scss
@@ -4,4 +4,5 @@
 @use './topbar';
 @use './sidebar';
 @use './menu';
+@use './table';
 @use './main';

--- a/src/layout/AppLayout.vue
+++ b/src/layout/AppLayout.vue
@@ -1,4 +1,5 @@
 <script setup>
+import DynamicDialog from 'primevue/dynamicdialog';
 import AppTopbar from './AppTopbar.vue';
 import AppSidebar from './AppSidebar.vue';
 </script>
@@ -12,5 +13,6 @@ import AppSidebar from './AppSidebar.vue';
         <router-view />
       </div>
     </div>
+    <DynamicDialog />
   </div>
 </template>

--- a/src/layout/AppSidebar.vue
+++ b/src/layout/AppSidebar.vue
@@ -1,5 +1,4 @@
 <script setup>
-import Menu from 'primevue/menu'
 import { computed } from 'vue'
 
 const items = computed(() => [

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import router from './router'
 
 import PrimeVue from 'primevue/config'
 import Aura from '@primeuix/themes/aura'
+import DialogService from 'primevue/dialogservice';
 
 const app = createApp(App)
 
@@ -20,5 +21,6 @@ app.use(PrimeVue, {
     }
   }
 })
+app.use(DialogService)
 
 app.mount('#app')

--- a/src/views/pages/POSales.vue
+++ b/src/views/pages/POSales.vue
@@ -1,58 +1,20 @@
 <script setup>
-import { computed, onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useSalesStore } from '@/stores/sales';
-import { formatDate } from '@/utils/formatDate';
-import AddSalesForm from '@/components/AddSalesForm.vue';
 import POSalesTable from '@/components/table/POSalesTable.vue';
 
-const month = ref(formatDate(new Date(), 'm-y'));
-const tab = ref('all');
 const salesStore = useSalesStore();
 const { sales } = storeToRefs(salesStore);
 
 onMounted(async () => await salesStore.fetchSales());
-
-const getSales = computed(() => {
-  const date = new Date(month.value);
-  if (tab.value === 'month') {
-    return sales.value.filter((sale) => {
-      const saleDate = new Date(sale.purchaseDate);
-      return saleDate.getMonth() === date.getMonth() && saleDate.getFullYear() === date.getFullYear();
-    });
-  }
-  return sales.value;
-})
 </script>
 
 <template>
   <div class="card">
     <div class="card-title">PO Card Sales</div>
-    <!-- <div>
-      <AddSalesForm />
-    </div> -->
-    <div>
-      <!-- <div>
-        <div class="btn-group">
-          <button type="button":class="{ 'active': tab === 'all' }" @click="tab = 'all'">All</button>
-          <button type="button" :class="{ 'active': tab === 'month' }" @click="tab = 'month'">By Month</button>
-        </div>
-      </div> -->
-
-      <div v-if="tab === 'month'">
-        <input type="month" v-model="month" />
-      </div>
-      <POSalesTable :sales="getSales" />
+    <div class="card-content">
+      <POSalesTable :sales="sales" />
     </div>
   </div>
 </template>
-
-<style scoped>
-.btn-group button {
-  color: var(--bs-secondary);
-  background: none;
-  &.active {
-    color: rgba(0, 0, 0, 1);
-  }
-}
-</style>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,11 +4,17 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
+import Components from 'unplugin-vue-components/vite'
+import { PrimeVueResolver } from '@primevue/auto-import-resolver'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     vue(),
     vueDevTools(),
+    Components({
+      resolvers: [PrimeVueResolver()],
+    }),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
- install unplugin-vue-components and primevue/auto-import-resolver
- define new plugins in vite.config

refactor: update POSales component by transfering AddSalesForm inside the POSalesTable
refactor: apply primevue components to POSalesTable

- change table to DataTable with pagination
- add global filters where users can search name and amount
- add filter functions on Purchase Date column
- transfer the AddSalesForm and put it inside a modal
- create 'Add' function to trigger the opening of the modal
- add _table.scss for custom css